### PR TITLE
Conditionally compile PCSC deps with 'pcsc' feature

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5402,6 +5402,7 @@ dependencies = [
  "solana-logger 1.16.0",
  "solana-program-runtime",
  "solana-pubsub-client",
+ "solana-remote-keypair",
  "solana-remote-wallet",
  "solana-rpc-client",
  "solana-rpc-client-api",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -340,7 +340,7 @@ solana-program-test = { path = "program-test", version = "=1.16.0" }
 solana-pubsub-client = { path = "pubsub-client", version = "=1.16.0" }
 solana-quic-client = { path = "quic-client", version = "=1.16.0" }
 solana-rayon-threadlimit = { path = "rayon-threadlimit", version = "=1.16.0" }
-solana-remote-keypair = { path = "remote-keypair", version = "=1.16.0", default-features = false }
+solana-remote-keypair = { path = "remote-keypair", version = "=1.16.0" }
 solana-remote-wallet = { path = "remote-wallet", version = "=1.16.0", default-features = false }
 solana-rpc = { path = "rpc", version = "=1.16.0" }
 solana-rpc-client = { path = "rpc-client", version = "=1.16.0", default-features = false }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -242,7 +242,7 @@ num-derive = "0.3"
 num-traits = "0.2"
 once_cell = "1.13.0"
 openpgp-card = "0.3.3"
-openpgp-card-pcsc = "0.3.0"
+openpgp-card-pcsc = { version = "0.3.0", default-features = false }
 openssl = "0.10"
 ouroboros = "0.15.6"
 parking_lot = "0.12"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -242,7 +242,7 @@ num-derive = "0.3"
 num-traits = "0.2"
 once_cell = "1.13.0"
 openpgp-card = "0.3.3"
-openpgp-card-pcsc = { version = "0.3.0", default-features = false }
+openpgp-card-pcsc = "0.3.0"
 openssl = "0.10"
 ouroboros = "0.15.6"
 parking_lot = "0.12"
@@ -340,7 +340,7 @@ solana-program-test = { path = "program-test", version = "=1.16.0" }
 solana-pubsub-client = { path = "pubsub-client", version = "=1.16.0" }
 solana-quic-client = { path = "quic-client", version = "=1.16.0" }
 solana-rayon-threadlimit = { path = "rayon-threadlimit", version = "=1.16.0" }
-solana-remote-keypair = { path = "remote-keypair", version = "=1.16.0" }
+solana-remote-keypair = { path = "remote-keypair", version = "=1.16.0", default-features = false }
 solana-remote-wallet = { path = "remote-wallet", version = "=1.16.0", default-features = false }
 solana-rpc = { path = "rpc", version = "=1.16.0" }
 solana-rpc-client = { path = "rpc-client", version = "=1.16.0", default-features = false }

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -39,6 +39,7 @@ solana-faucet = { workspace = true }
 solana-logger = { workspace = true }
 solana-program-runtime = { workspace = true }
 solana-pubsub-client = { workspace = true }
+solana-remote-keypair = { workspace = true }
 solana-remote-wallet = { workspace = true, features = ["default"] }
 solana-rpc-client = { workspace = true, features = ["default"] }
 solana-rpc-client-api = { workspace = true }
@@ -57,6 +58,9 @@ tiny-bip39 = { workspace = true }
 solana-streamer = { workspace = true }
 solana-test-validator = { workspace = true }
 tempfile = { workspace = true }
+
+[features]
+pcsc = ["solana-remote-keypair/default"]
 
 [[bin]]
 name = "solana"

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -60,7 +60,7 @@ solana-test-validator = { workspace = true }
 tempfile = { workspace = true }
 
 [features]
-pcsc = ["solana-remote-keypair/default"]
+pcsc = ["solana-remote-keypair/pcsc"]
 
 [[bin]]
 name = "solana"

--- a/remote-keypair/Cargo.toml
+++ b/remote-keypair/Cargo.toml
@@ -11,12 +11,15 @@ edition = { workspace = true }
 
 [dependencies]
 openpgp-card = { workspace = true }
-openpgp-card-pcsc = { workspace = true }
+openpgp-card-pcsc = { workspace = true, optional = true }
 pinentry = { workspace = true }
 secrecy = { workspace = true }
 solana-sdk = { workspace = true }
 thiserror = { workspace = true }
 uriparse = { workspace = true }
+
+[features]
+default = ["openpgp-card-pcsc"]
 
 [lib]
 name = "solana_remote_keypair"

--- a/remote-keypair/Cargo.toml
+++ b/remote-keypair/Cargo.toml
@@ -19,7 +19,7 @@ thiserror = { workspace = true }
 uriparse = { workspace = true }
 
 [features]
-default = ["openpgp-card-pcsc"]
+pcsc = ["openpgp-card-pcsc"]
 
 [lib]
 name = "solana_remote_keypair"

--- a/remote-keypair/src/openpgp_card.rs
+++ b/remote-keypair/src/openpgp_card.rs
@@ -147,7 +147,8 @@ impl TryFrom<&Locator> for OpenpgpCard {
     #[cfg(not(feature = "openpgp-card-pcsc"))]
     fn try_from(_locator: &Locator) -> Result<Self, Self::Error> {
         Err(Self::Error::UnsupportedFeature(
-            "openpgp-card-pcsc crate compilation disabled in solana-remote-keypair.".to_string(),
+            "openpgp-card-pcsc crate compilation disabled in solana-remote-keypair. \
+            Rebuild with `--features pcsc`.".to_string(),
         ))
     }
 }

--- a/remote-keypair/src/openpgp_card.rs
+++ b/remote-keypair/src/openpgp_card.rs
@@ -1,13 +1,16 @@
+#[cfg(feature = "openpgp-card-pcsc")]
+use {
+    openpgp_card::SmartcardError,
+    openpgp_card_pcsc::PcscBackend,
+};
 use {
     openpgp_card::{
         algorithm::{Algo, Curve},
         crypto_data::{EccType, PublicKeyMaterial, Hash},
         OpenPgp,
-        SmartcardError,
         card_do::{UIF, ApplicationIdentifier},
         OpenPgpTransaction
     },
-    openpgp_card_pcsc::PcscBackend,
     pinentry::PassphraseInput,
     secrecy::ExposeSecret,
     solana_sdk::{
@@ -116,6 +119,7 @@ pub struct OpenpgpCard {
 impl TryFrom<&Locator> for OpenpgpCard {
     type Error = openpgp_card::Error;
 
+    #[cfg(feature = "openpgp-card-pcsc")]
     fn try_from(locator: &Locator) -> Result<Self, Self::Error> {
         let pcsc_identifier = locator.aid.as_ref().map(|x| x.ident());
         let backend = match pcsc_identifier {
@@ -123,7 +127,7 @@ impl TryFrom<&Locator> for OpenpgpCard {
             None => {
                 let mut cards = PcscBackend::cards(None)?;
                 if cards.is_empty() {
-                    return Err(openpgp_card::Error::Smartcard(SmartcardError::NoReaderFoundError))
+                    return Err(Self::Error::Smartcard(SmartcardError::NoReaderFoundError))
                 } else {
                     cards.remove(0)
                 }
@@ -138,6 +142,13 @@ impl TryFrom<&Locator> for OpenpgpCard {
             pgp: RefCell::new(pgp),
             pin_verified: RefCell::new(false),
         })
+    }
+
+    #[cfg(not(feature = "openpgp-card-pcsc"))]
+    fn try_from(_locator: &Locator) -> Result<Self, Self::Error> {
+        Err(Self::Error::UnsupportedFeature(
+            "openpgp-card-pcsc crate compilation disabled in solana-remote-keypair.".to_string(),
+        ))
     }
 }
 


### PR DESCRIPTION
Add `pcsc` feature to `cli` and `remote-keypair` members to conditionally enable compilation of PCSC-related dependencies.